### PR TITLE
Two small fixes that help this compile with the LLVM shipped in Xcode 4.3.2.

### DIFF
--- a/Classes/JWConstraint.h
+++ b/Classes/JWConstraint.h
@@ -22,7 +22,7 @@
 //  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 //  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef enum {
     kJWConstraintMinX = 1 << 0,

--- a/Classes/JWConstraintGraphNode.m
+++ b/Classes/JWConstraintGraphNode.m
@@ -60,25 +60,25 @@
 - (void)addIncoming:(JWConstraintGraphNode*)aNode;
 {
     if (![self.incomingEdges containsObject:aNode])
-        [self.incomingEdges addObject:aNode];
+        [(NSMutableArray *)self.incomingEdges addObject:aNode];
 }
 
 - (void)addOutgoing:(JWConstraintGraphNode*)aNode;
 {
     if (![self.outgoingEdges containsObject:aNode])
-        [self.outgoingEdges addObject:aNode];
+        [(NSMutableArray *)self.outgoingEdges addObject:aNode];
 }
 
 - (void)removeOutgoing:(JWConstraintGraphNode*)aNode;
 {
     if ([self.outgoingEdges containsObject:aNode])
-        [self.outgoingEdges removeObject:aNode];
+        [(NSMutableArray *)self.outgoingEdges removeObject:aNode];
 }
 
 - (void)removeIncoming:(JWConstraintGraphNode*)aNode;
 {
     if ([self.incomingEdges containsObject:aNode])
-        [self.incomingEdges removeObject:aNode];
+        [(NSMutableArray *)self.incomingEdges removeObject:aNode];
 }
 
 #pragma mark Debugging


### PR DESCRIPTION
- Include UIKit.h in one of the files that was using CGFloat, but only including Foundation.h
- A few casts of private NSMutableArrays to cope with LLVM's different idea of how properties override method declarations.
