### PR TITLE
Feature/fix superview relative attribute values

### DIFF
--- a/Classes/JWConstraint.m
+++ b/Classes/JWConstraint.m
@@ -115,8 +115,8 @@
     if (self.relativeView)
         frame = [[superview jw_subviewWithName:self.relativeView] frame];
     else
-        frame = [superview frame];
     
+        frame = [superview bounds];
     CGFloat rVal = 0.0f;
     switch (self.relativeAttribute)
     {

--- a/Classes/JWConstraintLayoutManager.m
+++ b/Classes/JWConstraintLayoutManager.m
@@ -161,15 +161,19 @@ int attribute_to_axis(JWConstraintAttribute attribute)
         [queue removeObjectAtIndex:0];
         [self.nodes insertObject:node atIndex:0];
         
+        NSMutableArray *outgoingEdgesToRemove = [NSMutableArray array];
         for (JWConstraintGraphNode *outgoing in [node outgoingEdges])
         {
-            [node removeOutgoing:outgoing];
+            [outgoingEdgesToRemove addObject:outgoing];
             [outgoing removeIncoming:node];
             if ([[outgoing incomingEdges] count] == 0)
             {
                 [queue addObject:outgoing];
             }
         }
+
+        for (JWConstraintGraphNode *outgoing in outgoingEdgesToRemove)
+             [node removeOutgoing:outgoing];
     }
     
     for (JWConstraintGraphNode *node in allNodes)

--- a/JWLayoutViews.podspec
+++ b/JWLayoutViews.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+  s.name         = "JWLayoutViews"
+  s.version      = "0.0.1"
+  s.summary      = "better(?) layout systems for iOS."
+  s.description  = <<-DESC
+                      'Real' layout controls for iOS
+
+                      Currently have two layout systems, a wrapping layout view 
+                      and a constraint based system.
+                      DESC
+  s.homepage     = "https://github.com/jweinberg/JWLayoutViews/"
+  s.license      = 'BSD'
+  s.author       = { "Joshua Weinberg" => "joshuacweinberg@gmail.com" }
+  s.source       = { :git => "https://github.com/jweinberg/JWLayoutViews.git", :tag => '0.0.1' }
+  s.platform     = :ios, '4.0'
+  s.source_files = 'Classes', 'Classes/**/*.{h,m}'
+  s.frameworks = 'Foundation', 'UIKit', 'CoreGraphics'
+  s.requires_arc = false
+end


### PR DESCRIPTION
To vertically center a view on its superview, I should be able to specify (in pseudo-code):

```
view("button").midY = view(nil).midY
```

but since the current code uses the superview's frame rather than its bounds, this results in the subview being pushed clear off of its superview.

If I'm misunderstanding how this should work, let me know.  Otherwise, please accept!
