### PR TITLE
make attributes relative to a superview's bounds

### DIFF
--- a/Classes/JWConstraint.m
+++ b/Classes/JWConstraint.m
@@ -115,8 +115,8 @@
     if (self.relativeView)
         frame = [[superview jw_subviewWithName:self.relativeView] frame];
     else
-        frame = [superview frame];
     
+        frame = [superview bounds];
     CGFloat rVal = 0.0f;
     switch (self.relativeAttribute)
     {

--- a/Classes/JWConstraint.m
+++ b/Classes/JWConstraint.m
@@ -115,7 +115,6 @@
     if (self.relativeView)
         frame = [[superview jw_subviewWithName:self.relativeView] frame];
     else
-    
         frame = [superview bounds];
     CGFloat rVal = 0.0f;
     switch (self.relativeAttribute)


### PR DESCRIPTION
To vertically center a view on its superview, I should be able to specify (in pseudo-code):

```
view("button").midY = view(nil).midY
```

but since the current code uses the superview's frame rather than its bounds, this results in the subview being pushed clear off of its superview.

If I'm misunderstanding how this should work, let me know.  Otherwise, please accept!
